### PR TITLE
BUGFIX: Prevent selection of next div when double clicking Icon elements

### DIFF
--- a/src/Components/ArticleCard/ArticleCard.jsx
+++ b/src/Components/ArticleCard/ArticleCard.jsx
@@ -28,6 +28,7 @@ const ArticleCard = ({ data }) => {
           <div className={styles.title}>{data?.title}</div>
         </Link>
         <Icon
+          className={styles.icon}
           icon={
             bookmarked ? "material-symbols:bookmark" : "material-symbols:bookmark-outline"
           }

--- a/src/Components/ArticleCard/ArticleCard.module.scss
+++ b/src/Components/ArticleCard/ArticleCard.module.scss
@@ -9,6 +9,9 @@
     justify-content: space-between;
     align-items: center;
     cursor: pointer;
+    .icon {
+      user-select: none;
+    }
   }
 
   .title {

--- a/src/Components/BookmarkCard/BookmarkCard.jsx
+++ b/src/Components/BookmarkCard/BookmarkCard.jsx
@@ -47,13 +47,13 @@ const BookmarkCard = ({ data }) => {
         <div className={styles.controls}>
           {controlIcons.map((item, index) => {
             return (
-              <div key={index}>
-                <Icon
-                  icon={item.iconState ? item.filledIcon : item.outlinedIcon}
-                  height="30"
-                  onClick={item.iconStateHandler}
-                />
-              </div>
+              <Icon
+                id={index}
+                className={styles.icon}
+                icon={item.iconState ? item.filledIcon : item.outlinedIcon}
+                height="30"
+                onClick={item.iconStateHandler}
+              />
             );
           })}
         </div>

--- a/src/Components/BookmarkCard/BookmarkCard.module.scss
+++ b/src/Components/BookmarkCard/BookmarkCard.module.scss
@@ -64,6 +64,9 @@
       display: flex;
       align-items: center;
       margin-left: auto;
+      .icon {
+        user-select: none;
+      }
     }
   }
 }


### PR DESCRIPTION
```
BUG: When double clicking an Icon element, it triggers highlight on the
     next div text. For example, in Bookmarks page, try double clicking
     the bookmark icon. It will highlight the next bookmark card's
     title.

EXPECTED: Donot highlight the next div's text when double clicking an
          Icon element.

FIX: Apply `user-select: none` to the Icon tags.
```