### PR TITLE
BUGFIX: Scroll to top of Page on changing pages

### DIFF
--- a/src/Components/ScrollToTop/ScrollToTop.jsx
+++ b/src/Components/ScrollToTop/ScrollToTop.jsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/Components/index.jsx
+++ b/src/Components/index.jsx
@@ -12,6 +12,7 @@ import TopWriters from "./TopWriters/TopWriters";
 import SuggestedPosts from "./SuggestedPosts/SuggestedPosts";
 import Author from "./Author/Author";
 import Share from "./Share/Share";
+import ScrollToTop from "./ScrollToTop/ScrollToTop";
 
 export {
   Button,
@@ -28,4 +29,5 @@ export {
   SuggestedPosts,
   Author,
   Share,
+  ScrollToTop,
 };

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import AuthProvider from "./Global/Auth/AuthProvider";
+import { ScrollToTop } from "./Components";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.scss";
@@ -9,6 +10,7 @@ ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <AuthProvider>
       <BrowserRouter>
+        <ScrollToTop />
         <App />
       </BrowserRouter>
     </AuthProvider>


### PR DESCRIPTION
BUG: Whenever moving through pages, the position
of page remains the same even in the new page.
For ex, in the homepage, try opening the last article. It should open the 404 page since the route does not exist yet. But the 404 page is opened from the same position from where we left the home page.

To fix this, see this Stack Overflow Answer:

https://stackoverflow.com/a/61602724/12982627